### PR TITLE
Add GraphX based RDF model implementation

### DIFF
--- a/src/main/scala/org/dissect/rdf/spark/model/GraphxGraphOps.scala
+++ b/src/main/scala/org/dissect/rdf/spark/model/GraphxGraphOps.scala
@@ -1,0 +1,140 @@
+package org.dissect.rdf.spark.model
+
+import org.apache.spark.SparkContext
+import org.apache.spark.graphx.PartitionStrategy.RandomVertexCut
+import org.apache.spark.rdd.RDD
+import org.apache.spark.graphx.{Graph => SparkGraph, EdgeTriplet, VertexId, Edge}
+
+import scala.util.hashing.MurmurHash3
+
+/**
+ * Spark/GraphX based implementation of RDFGraphOps
+ *
+ * @author Nilesh Chakraborty <nilesh@nileshc.com>
+ */
+trait GraphxGraphOps[Rdf <: SparkGraphX]
+  extends RDFGraphOps[Rdf]
+  with URIOps[Rdf]
+  with RDFDSL[Rdf] { this: RDFNodeOps[Rdf] =>
+
+  protected val sparkContext: SparkContext
+
+  // graph
+
+  protected def makeGraph(triples: Iterable[Rdf#Triple]): Rdf#Graph = {
+    val triplesRDD = sparkContext.parallelize(triples.toSeq)
+    makeGraph(triplesRDD)
+  }
+
+  protected def makeGraph(triples: RDD[Rdf#Triple]): Rdf#Graph = {
+    val spo: RDD[(Rdf#Node, (Rdf#URI, Rdf#Node))] = triples.map {
+      case Triple(s, p, o) => (s, (p, o))
+    }
+
+    val vertexIDs = spo.flatMap {
+      case (s: Rdf#Node, (p: Rdf#URI, o: Rdf#Node)) =>
+        Seq(s, p.asInstanceOf[Rdf#Node], o)
+    }.zipWithUniqueId()
+
+    val vertices: RDD[(VertexId, Rdf#Node)] = vertexIDs.map(v => (v._2, v._1))
+
+    val subjectMappedEdges = spo.join(vertexIDs).map {
+      case (s: Rdf#Node, ((p: Rdf#URI, o: Rdf#Node), sid: Long)) =>
+        (o, (sid, p))
+    }
+
+    val subjectObjectMappedEdges: RDD[Edge[Rdf#URI]] = subjectMappedEdges.join(vertexIDs).map {
+      case (o: Rdf#Node, ((sid: Long, p: Rdf#URI), oid: Long)) =>
+        Edge(sid, oid, p)
+    }
+
+    val subjectVertexIds: RDD[(VertexId, Option)] = subjectObjectMappedEdges.map(x => (x.srcId, None))
+    val objectVertexIds: RDD[(VertexId, Option)] = subjectObjectMappedEdges.map(x => (x.dstId, None))
+
+    SparkGraph(vertices, subjectObjectMappedEdges)
+  }
+
+  protected def makeHashedVertexGraph(triples: RDD[Rdf#Triple]): Rdf#Graph = {
+    val spo: RDD[(Rdf#Node, Rdf#URI, Rdf#Node)] = triples.map {
+      case Triple(s, p, o) => (s, p, o)
+    }
+
+    def hash(s: Rdf#Node) = MurmurHash3.stringHash(s.toString).toLong
+
+    val vertices: RDD[(VertexId, Rdf#Node)] = spo.flatMap {
+      case (s: Rdf#Node, p: Rdf#URI, o: Rdf#Node) =>
+        Seq((hash(s), s), (hash(p), p), (hash(o), o))
+    }
+
+    val edges: RDD[Edge[Rdf#URI]] = spo.map {
+      case (s: Rdf#Node, p: Rdf#URI, o: Rdf#Node) =>
+        Edge(hash(s), hash(o), p)
+    }
+
+    SparkGraph(vertices, edges)
+  }
+
+  protected def getTriples(graph: Rdf#Graph): Iterable[Rdf#Triple] =
+    graph.triplets.map(x => Triple(x.srcAttr, x.attr, x.dstAttr)).toLocalIterator.toIterable
+
+  // graph traversal
+
+  protected def getObjectsRDD(graph: Rdf#Graph, subject: Rdf#Node, predicate: Rdf#URI): RDD[Rdf#Node] =
+    findGraph(graph, toConcreteNodeMatch(subject), toConcreteNodeMatch(predicate), ANY).triplets.map(_.dstAttr)
+
+  protected def getObjectsRDD(graph: Rdf#Graph, predicate: Rdf#URI): RDD[Rdf#Node] =
+    findGraph(graph, ANY, toConcreteNodeMatch(predicate), ANY).triplets.map(_.dstAttr)
+
+  protected def getPredicatesRDD(graph: Rdf#Graph, subject: Rdf#Node): RDD[Rdf#URI] =
+    findGraph(graph, toConcreteNodeMatch(subject), ANY, ANY).triplets.map(_.attr)
+
+  protected def getSubjectsRDD(graph: Rdf#Graph, predicate: Rdf#URI, obj: Rdf#Node): RDD[Rdf#Node] =
+    findGraph(graph, ANY, toConcreteNodeMatch(predicate), toConcreteNodeMatch(obj)).triplets.map(_.srcAttr)
+
+  protected def getSubjectsRDD(graph: Rdf#Graph, predicate: Rdf#URI): RDD[Rdf#Node] =
+    findGraph(graph, ANY, toConcreteNodeMatch(predicate), ANY).triplets.map(_.srcAttr)
+
+  // graph traversal
+
+  protected def findGraph(graph: Rdf#Graph, subject: Rdf#NodeMatch, predicate: Rdf#NodeMatch, objectt: Rdf#NodeMatch): Rdf#Graph = {
+    graph.subgraph({
+      (triplet: EdgeTriplet[Rdf#Node, Rdf#URI]) =>
+        matchNode(triplet.srcAttr, subject) && matchNode(triplet.attr, predicate) && matchNode(triplet.dstAttr, objectt)
+    }, (_, _) => true)
+  }
+
+  protected def find(graph: Rdf#Graph, subject: Rdf#NodeMatch, predicate: Rdf#NodeMatch, objectt: Rdf#NodeMatch): Iterator[Rdf#Triple] =
+    findGraph(graph, subject, predicate, objectt).triplets.map(x => Triple(x.srcAttr, x.attr, x.dstAttr)).toLocalIterator
+
+  // graph operations
+
+  protected def union(graphs: Seq[Rdf#Graph]): Rdf#Graph =
+    graphs.reduce {
+      case (left: Rdf#Graph, right: Rdf#Graph) =>
+        val newGraph = SparkGraph(left.vertices.union(right.vertices), left.edges.union(right.edges))
+        newGraph.partitionBy(RandomVertexCut).groupEdges( (attr1, attr2) => attr1 )
+    }
+
+  protected def intersection(graphs: Seq[Rdf#Graph]): Rdf#Graph =
+    graphs.reduce {
+      case (left: Rdf#Graph, right: Rdf#Graph) =>
+        val newGraph = SparkGraph(left.vertices.intersection(right.vertices), left.edges.intersection(right.edges))
+        newGraph.partitionBy(RandomVertexCut).groupEdges( (attr1, attr2) => attr1 )
+    }
+
+  protected def difference(g1: Rdf#Graph, g2: Rdf#Graph): Rdf#Graph = {
+    /// subtract triples; edge triplet intersection is collected into memory - is there a better way? Joining somehow?
+    val matchingTriplets = g1.triplets.intersection(g2.triplets).collect().toSet
+    g1.subgraph({
+      (triplet: EdgeTriplet[Rdf#Node, Rdf#URI]) =>
+        matchingTriplets.contains(triplet)
+    }, (_, _) => true)
+  }
+
+  /**
+   * Implement Spark algorithm for determining whether left and right are isomorphic
+   */
+  protected def isomorphism(left: Rdf#Graph, right: Rdf#Graph): Boolean = ???
+
+  protected def graphSize(g: Rdf#Graph): Long = g.numEdges
+}

--- a/src/main/scala/org/dissect/rdf/spark/model/JenaSparkRDD.scala
+++ b/src/main/scala/org/dissect/rdf/spark/model/JenaSparkRDD.scala
@@ -28,3 +28,7 @@ trait Jena extends RDF {
 trait SparkRDD extends RDF {
   type Graph = RDD[Triple]
 }
+
+trait SparkGraphX extends RDF {
+  type Graph = SparkGraph[Node, URI]
+}

--- a/src/main/scala/org/dissect/rdf/spark/model/JenaSparkRDD.scala
+++ b/src/main/scala/org/dissect/rdf/spark/model/JenaSparkRDD.scala
@@ -2,13 +2,14 @@ package org.dissect.rdf.spark.model
 
 import org.apache.jena.graph.{Triple => JenaTriple, Node => JenaNode, Node_ANY, Node_Literal, Node_Blank, Node_URI}
 import org.apache.spark.rdd.RDD
+import org.apache.spark.graphx.{Graph => SparkGraph}
 
 /**
  * The JenaSpark model works with Jena and Spark RDDs.
  *
  * @author Nilesh Chakraborty <nilesh@nileshc.com>
  */
-trait JenaSpark extends Jena with SparkRDD
+trait JenaSparkRDD extends Jena with SparkRDD
 
 trait Jena extends RDF {
   // types related to the RDF data model

--- a/src/main/scala/org/dissect/rdf/spark/model/SparkRDDGraphOps.scala
+++ b/src/main/scala/org/dissect/rdf/spark/model/SparkRDDGraphOps.scala
@@ -21,7 +21,7 @@ trait SparkRDDGraphOps[Rdf <: SparkRDD]
     sparkContext.parallelize(triples.toSeq)
 
   protected def getTriples(graph: Rdf#Graph): Iterable[Rdf#Triple] =
-    graph.collect()
+    graph.toLocalIterator.toIterable
 
   // graph traversal
 
@@ -49,9 +49,8 @@ trait SparkRDDGraphOps[Rdf <: SparkRDD]
     }
   }
 
-  protected def find(graph: Rdf#Graph, subject: Rdf#NodeMatch, predicate: Rdf#NodeMatch, objectt: Rdf#NodeMatch): Iterator[Rdf#Triple] = {
+  protected def find(graph: Rdf#Graph, subject: Rdf#NodeMatch, predicate: Rdf#NodeMatch, objectt: Rdf#NodeMatch): Iterator[Rdf#Triple] =
     findGraph(graph, subject, predicate, objectt).toLocalIterator
-  }
 
   // graph operations
 

--- a/src/main/scala/org/dissect/rdf/spark/model/SparkRDDGraphOps.scala
+++ b/src/main/scala/org/dissect/rdf/spark/model/SparkRDDGraphOps.scala
@@ -8,7 +8,7 @@ import org.apache.spark.rdd.RDD
  *
  * @author Nilesh Chakraborty <nilesh@nileshc.com>
  */
-trait SparkGraphOps[Rdf <: SparkRDD]
+trait SparkRDDGraphOps[Rdf <: SparkRDD]
   extends RDFGraphOps[Rdf]
   with URIOps[Rdf]
   with RDFDSL[Rdf] { this: RDFNodeOps[Rdf] =>

--- a/src/main/scala/org/dissect/rdf/spark/model/TripleRDD.scala
+++ b/src/main/scala/org/dissect/rdf/spark/model/TripleRDD.scala
@@ -7,88 +7,88 @@ import org.apache.spark.rdd.RDD
  *
  * @author Nilesh Chakraborty <nilesh@nileshc.com>, Gezim Sejdiu <g.sejdiu@gmail.com>
  */
-class TripleRDD(graphRDD: JenaSpark#Graph) extends JenaNodeOps[JenaSpark] with SparkGraphOps[JenaSpark] {
+class TripleRDD(graphRDD: JenaSparkRDD#Graph) extends JenaNodeOps[JenaSparkRDD] with SparkRDDGraphOps[JenaSparkRDD] {
   val sparkContext = graphRDD.sparkContext
 
-  def getTriples: Iterable[JenaSpark#Triple] =
+  def getTriples: Iterable[JenaSparkRDD#Triple] =
     getTriples(graphRDD)
 
-  def getSubjects: RDD[JenaSpark#Node] =
+  def getSubjects: RDD[JenaSparkRDD#Node] =
     graphRDD.map(_.getSubject)
 
-  def getPredicates: RDD[JenaSpark#Node] =
+  def getPredicates: RDD[JenaSparkRDD#Node] =
     graphRDD.map(_.getPredicate)
 
-  def getObjects: RDD[JenaSpark#Node] =
+  def getObjects: RDD[JenaSparkRDD#Node] =
     graphRDD.map(_.getObject)
 
-  def getSubjectsWithPredicate(predicate: JenaSpark#URI): RDD[JenaSpark#Node] =
+  def getSubjectsWithPredicate(predicate: JenaSparkRDD#URI): RDD[JenaSparkRDD#Node] =
     getSubjectsRDD(graphRDD, predicate)
 
-  def getSubjectsWithPredicate(predicate: JenaSpark#URI, objectt: JenaSpark#Node): RDD[JenaSpark#Node] =
+  def getSubjectsWithPredicate(predicate: JenaSparkRDD#URI, objectt: JenaSparkRDD#Node): RDD[JenaSparkRDD#Node] =
     getSubjectsRDD(graphRDD, predicate, objectt)
 
-  def getObjectsWithPredicate(predicate: JenaSpark#URI): RDD[JenaSpark#Node] =
+  def getObjectsWithPredicate(predicate: JenaSparkRDD#URI): RDD[JenaSparkRDD#Node] =
     getObjectsRDD(graphRDD, predicate)
 
-  def getObjectsWithPredicate(subject: JenaSpark#Node, predicate: JenaSpark#URI): RDD[JenaSpark#Node] =
+  def getObjectsWithPredicate(subject: JenaSparkRDD#Node, predicate: JenaSparkRDD#URI): RDD[JenaSparkRDD#Node] =
     getObjectsRDD(graphRDD, subject, predicate)
 
-  def mapSubjects(func: (JenaSpark#Node) => JenaSpark#Node): JenaSpark#Graph = {
+  def mapSubjects(func: (JenaSparkRDD#Node) => JenaSparkRDD#Node): JenaSparkRDD#Graph = {
     graphRDD.map {
       case Triple(s, p, o) => Triple(func(s), p, o)
     }
   }
 
-  def mapPredicates(func: (JenaSpark#URI) => JenaSpark#URI): JenaSpark#Graph = {
+  def mapPredicates(func: (JenaSparkRDD#URI) => JenaSparkRDD#URI): JenaSparkRDD#Graph = {
     graphRDD.map {
       case Triple(s, p, o) => Triple(s, func(p), o)
     }
   }
 
-  def mapObjects(func: (JenaSpark#Node) => JenaSpark#Node): JenaSpark#Graph = {
+  def mapObjects(func: (JenaSparkRDD#Node) => JenaSparkRDD#Node): JenaSparkRDD#Graph = {
     graphRDD.map {
       case Triple(s, p, o) => Triple(s, p, func(o))
     }
   }
 
-  def filterSubjects(func: (JenaSpark#Node) => Boolean): JenaSpark#Graph = {
+  def filterSubjects(func: (JenaSparkRDD#Node) => Boolean): JenaSparkRDD#Graph = {
     graphRDD.filter {
       case Triple(s, p, o) => func(s)
     }
   }
 
-  def filterPredicates(func: (JenaSpark#URI) => Boolean): JenaSpark#Graph = {
+  def filterPredicates(func: (JenaSparkRDD#URI) => Boolean): JenaSparkRDD#Graph = {
     graphRDD.filter {
       case Triple(s, p, o) => func(p)
     }
   }
 
-  def filterObjects(func: (JenaSpark#Node) => Boolean): JenaSpark#Graph = {
+  def filterObjects(func: (JenaSparkRDD#Node) => Boolean): JenaSparkRDD#Graph = {
     graphRDD.filter {
       case Triple(s, p, o) => func(o)
     }
   }
 
-  def mapURIs(func: (JenaSpark#URI) => JenaSpark#URI): JenaSpark#Graph = {
-    def mapper(n: JenaSpark#Node) = foldNode(n)(func, bnode => bnode, lit => lit)
+  def mapURIs(func: (JenaSparkRDD#URI) => JenaSparkRDD#URI): JenaSparkRDD#Graph = {
+    def mapper(n: JenaSparkRDD#Node) = foldNode(n)(func, bnode => bnode, lit => lit)
     graphRDD.map {
-      case Triple(s, p, o) => Triple(mapper(s), mapper(p).asInstanceOf[JenaSpark#URI], mapper(s))
+      case Triple(s, p, o) => Triple(mapper(s), mapper(p).asInstanceOf[JenaSparkRDD#URI], mapper(s))
     }
   }
 
-  def mapLiterals(func: (JenaSpark#Literal) => JenaSpark#Literal): JenaSpark#Graph = {
-    def mapper(n: JenaSpark#Node) = foldNode(n)(uri => uri, bnode => bnode, func)
+  def mapLiterals(func: (JenaSparkRDD#Literal) => JenaSparkRDD#Literal): JenaSparkRDD#Graph = {
+    def mapper(n: JenaSparkRDD#Node) = foldNode(n)(uri => uri, bnode => bnode, func)
     graphRDD.map {
       case Triple(s, p, o) => Triple(mapper(s), p, mapper(o))
     }
   }
 
-  def find(subject: JenaSpark#NodeMatch, predicate: JenaSpark#NodeMatch, objectt: JenaSpark#NodeMatch): JenaSpark#Graph =
+  def find(subject: JenaSparkRDD#NodeMatch, predicate: JenaSparkRDD#NodeMatch, objectt: JenaSparkRDD#NodeMatch): JenaSparkRDD#Graph =
     findGraph(graphRDD, subject, predicate, objectt)
 }
 
 
 object TripleRDD {
-  implicit def tripleFunctions(rdd: RDD[JenaSpark#Triple]): TripleRDD = new TripleRDD(rdd)
+  implicit def tripleFunctions(rdd: RDD[JenaSparkRDD#Triple]): TripleRDD = new TripleRDD(rdd)
 }

--- a/src/main/scala/org/dissect/rdf/spark/model/TripleSparkGraph.scala
+++ b/src/main/scala/org/dissect/rdf/spark/model/TripleSparkGraph.scala
@@ -1,0 +1,90 @@
+package org.dissect.rdf.spark.model
+
+import org.apache.spark.graphx._
+import org.apache.spark.rdd.RDD
+
+/**
+ * Implicit wrapper for functions for GraphX Graph of Jena Triples.
+ *
+ * @author Nilesh Chakraborty <nilesh@nileshc.com>
+ */
+class TripleSparkGraph(graph: SparkGraphX#Graph) extends JenaNodeOps[SparkGraphX] with GraphxGraphOps[SparkGraphX] {
+  val sparkContext = graph.edges.sparkContext
+
+  def getTriples: Iterable[SparkGraphX#Triple] =
+    getTriples(graph)
+
+  def getSubjects: RDD[SparkGraphX#Node] =
+    graph.triplets.map(_.srcAttr)
+
+  def getPredicates: RDD[SparkGraphX#Node] =
+    graph.triplets.map(_.attr)
+
+  def getObjects: RDD[SparkGraphX#Node] =
+    graph.triplets.map(_.dstAttr)
+
+  def getSubjectsWithPredicate(predicate: SparkGraphX#URI): RDD[SparkGraphX#Node] =
+    getSubjectsRDD(graph, predicate)
+
+  def getSubjectsWithPredicate(predicate: SparkGraphX#URI, objectt: SparkGraphX#Node): RDD[SparkGraphX#Node] =
+    getSubjectsRDD(graph, predicate, objectt)
+
+  def getObjectsWithPredicate(predicate: SparkGraphX#URI): RDD[SparkGraphX#Node] =
+    getObjectsRDD(graph, predicate)
+
+  def getObjectsWithPredicate(subject: SparkGraphX#Node, predicate: SparkGraphX#URI): RDD[SparkGraphX#Node] =
+    getObjectsRDD(graph, subject, predicate)
+
+  def mapSubjects(func: (SparkGraphX#Node) => SparkGraphX#Node): SparkGraphX#Graph = {
+    // probably expensive - computes RDD of source/subject vertices everytime
+    val sourceVertices: VertexRDD[Option] = graph.aggregateMessages[Option](ctx => ctx.sendToSrc(None), (_, _) => None)
+    graph.joinVertices(sourceVertices)((_, node, _) => func(node))
+  }
+
+  def mapPredicates(func: (SparkGraphX#URI) => SparkGraphX#URI): SparkGraphX#Graph = {
+    graph.mapEdges(x => func(x.attr))
+  }
+
+  def mapObjects(func: (SparkGraphX#Node) => SparkGraphX#Node): SparkGraphX#Graph = {
+    // probably expensive - computes RDD of destination/predicate vertices everytime
+    val destinationVertices: VertexRDD[Option] = graph.aggregateMessages[Option](ctx => ctx.sendToSrc(None), (_, _) => None)
+    graph.joinVertices(destinationVertices)((_, node, _) => func(node))
+  }
+
+  def filterSubjects(func: (SparkGraphX#Node) => Boolean): SparkGraphX#Graph = {
+    graph.subgraph({
+      triplet => func(triplet.srcAttr)
+    }, (_, _) => true)
+  }
+
+  def filterPredicates(func: (SparkGraphX#URI) => Boolean): SparkGraphX#Graph = {
+    graph.subgraph({
+      triplet => func(triplet.attr)
+    }, (_, _) => true)
+  }
+
+  def filterObjects(func: (SparkGraphX#Node) => Boolean): SparkGraphX#Graph = {
+    graph.subgraph({
+      triplet => func(triplet.dstAttr)
+    }, (_, _) => true)
+  }
+
+  def mapURIs(func: (SparkGraphX#URI) => SparkGraphX#URI): SparkGraphX#Graph = {
+    def mapper(n: SparkGraphX#Node) = foldNode(n)(func, bnode => bnode, lit => lit)
+    graph.mapEdges(x => func(x.attr)).mapVertices{
+      case (_: VertexId, node: SparkGraphX#Node) => mapper(node)
+    }
+  }
+
+  def mapLiterals(func: (SparkGraphX#Literal) => SparkGraphX#Literal): SparkGraphX#Graph = {
+    def mapper(n: SparkGraphX#Node) = foldNode(n)(uri => uri, bnode => bnode, func)
+    graph.mapVertices{
+      case (_: VertexId, node: SparkGraphX#Node) => mapper(node)
+    }
+  }
+
+  def find(subject: SparkGraphX#NodeMatch, predicate: SparkGraphX#NodeMatch, objectt: SparkGraphX#NodeMatch): SparkGraphX#Graph =
+    findGraph(graph, subject, predicate, objectt)
+}
+
+


### PR DESCRIPTION
Similar to existing RDD based impl, but works with Spark GraphX Graphs
* Added RDF ops code
* Added implicit wrapper for Graph[Node, URI]